### PR TITLE
Ability to run SSH using passed command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Python_FTP_and_SSH_connector
 This is a ssh and ftp connector created in python 
 
+## Usage
 Example of SSH connector executed in Ubuntu with Python 3.x
 ![alt text](https://github.com/kashishh2/Python_FTP_and_SSH_connector/blob/main/SSH_connect.PNG)
+
+Or use command line arguments in this format:
+`python ssh_connect.py ssh IpAddress port user passwrd command`

--- a/ssh_connect.py
+++ b/ssh_connect.py
@@ -1,15 +1,19 @@
 import paramiko
 import getpass
 import telnetlib
+import sys
 
-def sshconnect():
 
+def sshinput():
     IpAddress = input("Enter the ip address:")
     user = input("Enter the username:")
     passwrd = input("Enter the password:")
     port = 22
     command = input("Enter your command:")
 
+    sshconnect(IpAddress, port, user, passwrd, command)
+
+def sshconnect(IpAddress, port, user, passwrd, command):
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect(IpAddress, port, user, passwrd)
@@ -40,12 +44,26 @@ def telnetconnect():
 
 
 if __name__ == "__main__":
-    print("\n Please select a option: \n 1. SSH \n 2. Telnet")
-    option = int(input("Option:"))
-    if option == 1:
-        sshconnect()
-    elif option == 2:
-        telnetconnect()
+    # if there's passed arguments, parse them
+    if len(sys.argv) > 1:
+        # only ssh is supported in this format
+        if sys.argv[1] == "ssh":
+            IpAddress = sys.argv[2]
+            port = sys.argv[3]
+            user = sys.argv[4]
+            passwrd = sys.argv[5]
+            command = sys.argv[6]
+
+            sshconnect(IpAddress, port, user, passwrd, command)
+        else:
+            print("Please use other method for telnet")
     else:
-        print("Wrong option, terminating")
+        print("\n Please select a option: \n 1. SSH \n 2. Telnet")
+        option = int(input("Option:"))
+        if option == 1:
+            sshinput()
+        elif option == 2:
+            telnetconnect()
+        else:
+            print("Wrong option, terminating")
 


### PR DESCRIPTION
I created a quicker way to run the same underlying SSH code. The new format allows the user to add command line parameters which are parsed and put into the ssh connect method. I also put the port into this method because I need it for my project.

Only SSH (not telnet) is supported. There is no error checking of the parameters. Both of these things would be great to add as another Hacktoberfest contribution.